### PR TITLE
remove some duplicate lines and false positives (portals)

### DIFF
--- a/domains.txt
+++ b/domains.txt
@@ -61,7 +61,6 @@ akapost.com
 ak.mintemail.com
 alpenjodel.de
 alphafrau.de
-alt.del
 ama-trade.de
 ama-trans.de
 amilegit.com
@@ -81,7 +80,6 @@ antireg.com
 antireg.ru
 antispam24.de
 antispam.de
-apocarc.orc
 armyspy.com
 asdasd.ru
 asorent.com
@@ -209,7 +207,6 @@ dispose.it
 disposemail.com
 dispostable.com
 dm.w3internet.co.uk
-dm.w3internet.co.ukexample.com
 docmail.com
 docmail.cz
 docsis.ru
@@ -238,7 +235,6 @@ dumpmail.de
 dumpyemail.com
 duskmail.com
 dyndns.org
-*.e4ward.com
 *.e4ward.com
 e4ward.com
 easytrashmail.com
@@ -282,10 +278,8 @@ etranquil.com
 etranquil.net
 etranquil.org
 evopo.com
-example.com
 explodemail.com
 eyepaste.com
-facebook.com
 faecesmail.me
 fahr-zur-hoelle.org
 fakedemail.com
@@ -403,7 +397,6 @@ hidzz.com
 hmamail.com
 h.mintemail.com
 hochsitze.com
-home.de
 hooohush.ai
 hotpop.com
 huajiachem.cn
@@ -526,7 +519,6 @@ mailcatch.com
 maildrop.cc
 maileater.com
 *.mailexpire.com
-*.mailexpire.com
 mailexpire.com
 mailfa.tk
 mail-filter.com
@@ -534,7 +526,6 @@ mailforspam.com
 mailfreeonline.com
 mail.fsmash.org
 mailguard.me
-mail.htl22.at
 mailin8r.com
 mailinater.com
 *mailinator*
@@ -630,7 +621,7 @@ myspaceinc.net
 myspaceinc.org
 myspacepimpedup.com
 myspamless.com
-mytempemail
+mytempemail.*
 mytempemail.com
 mythrashmail.net
 mytop-in.net
@@ -656,7 +647,6 @@ nomail.xl.cx
 nomorespamemails.com
 nospam4.us
 nospamfor.us
-nospamforus
 no-spam.hu
 nospammail.net
 nospamthanks.info
@@ -670,7 +660,6 @@ nowmymail.com
 nullbox.info
 nur-fuer-spam.de
 nurfuerspam.de
-nus.edu.sg
 nwldx.com
 nybella.com
 objectmail.com
@@ -724,7 +713,6 @@ punkass.com
 put2.net
 putthisinyourspamdatabase.com
 pwrby.com
-qq.com
 quantentunnel.de
 quickinbox.com
 qv7.info
@@ -740,7 +728,6 @@ record.me
 recursor.net
 recyclemail.dk
 regbypass.com
-regbypass.comsafe-mail.net
 rejectmail.com
 rhyta.com
 rklips.com
@@ -925,7 +912,6 @@ tempthe.net
 tempymail.com
 terminverpennt.de
 test.com
-test.de
 thanksnospam.info
 thankyou2010.com
 thepryam.info
@@ -979,13 +965,11 @@ twinmail.de
 tyldd.com
 uggsrock.com
 uk2.net
-ukr.net
 umail.net
 unterderbruecke.de
 upliftnow.com
 uplipht.com
 uroid.com
-uubb.uubb
 venompen.com
 verlass-mich-nicht.de
 veryrealemail.com
@@ -1047,7 +1031,6 @@ wuzupmail.net
 wuzup.net
 www.e4ward.com
 www.gishpuppy.com
-www.mailinator.com
 wwwnew.eu
 xagloo.com
 xemaps.com
@@ -1059,8 +1042,6 @@ xoxy.net
 xsecurity.org
 xxtreamcam.com
 xyzfree.net
-yahoo.com.ph
-yahoo.com.vn
 yeah.net
 yep.it
 yesey.net


### PR DESCRIPTION
Thanks a lot for compiling the list. Now as part of https://github.com/disposable/disposable is gets more attention I think.

Some domains might come from spam reports but they're not disposable services. I found false positives when running against our user database.

- example.com, facebook.com -- User cannot send emails from those domains (Meta employees have fb.com as far as I know)
- test.de -- that's a German print magazine. I doubt users sent emails from there
- home.de -- these days a German ecommerce store. Possbility acquired the domain later
- mail.htl22.at -- Austrian university (https://www.htl-donaustadt.at/home)
- nus.edu.sg -- another university
- ukr.net -- big Ukranian portal
- qq.com -- big Chinease portal. Their usernames are numbers (e.g. 12345678) which makes them look spammy but not disposable
- yahoo.com.ph, yahoo.com.vn -- portal again
- uubb.uubb, alt.del, apocar.orc -- those top level domains don't exist, I doubt users sent any emails from there

- e4ward.com was listed twice
- mytempemail was missing a dot
- after splitting `regbypass.comsafe-mail.net` I saw both domains were already somewhere else in the list