### PR TITLE
remove email.com

### DIFF
--- a/domains.txt
+++ b/domains.txt
@@ -244,7 +244,6 @@ eintagsmail.de
 email4u.info
 email60.com
 e-mail.com
-email.com
 emaildienst.de
 emailgo.de
 emailias.com


### PR DESCRIPTION
email.com is a domain of freemailer mail.com

![image](https://github.com/user-attachments/assets/f4a35e9f-c0bd-4960-a24e-3d9889508a30)
